### PR TITLE
Add structured logging across backend services

### DIFF
--- a/backend/logging_config.py
+++ b/backend/logging_config.py
@@ -1,0 +1,53 @@
+"""Centralized logging configuration for the backend services."""
+
+import logging
+import os
+from logging.config import dictConfig
+from typing import Any, Dict
+
+
+def _build_logging_config(level: str) -> Dict[str, Any]:
+    """Return a dictConfig-style logging configuration.
+
+    Parameters
+    ----------
+    level: str
+        The log level to apply to the root logger.
+    """
+
+    formatter = {
+        "format": "%(asctime)s | %(levelname)-8s | %(name)s | %(message)s",
+    }
+
+    return {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {"default": formatter},
+        "handlers": {
+            "console": {
+                "class": "logging.StreamHandler",
+                "formatter": "default",
+            }
+        },
+        "root": {
+            "handlers": ["console"],
+            "level": level,
+        },
+    }
+
+
+def setup_logging() -> None:
+    """Configure logging for the application.
+
+    The configuration is applied only once even if the function is invoked
+    multiple times.
+    """
+
+    if getattr(setup_logging, "_configured", False):  # pragma: no cover - defensive
+        return
+
+    log_level = os.getenv("LOG_LEVEL", "INFO").upper()
+    dictConfig(_build_logging_config(log_level))
+    logging.getLogger(__name__).debug("Logging configured with level %s", log_level)
+    setattr(setup_logging, "_configured", True)
+

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,8 +1,15 @@
+import asyncio
+import logging
+
 from fastapi import FastAPI
+
+from backend.logging_config import setup_logging
 from backend.proxy_router import router as proxy_router
 from backend.node_manager import router as node_router
 from backend.monitor import start_monitor
-import asyncio
+
+setup_logging()
+logger = logging.getLogger(__name__)
 
 app = FastAPI(title="Appium/Selenium Proxy Server")
 
@@ -11,4 +18,5 @@ app.include_router(node_router)
 
 @app.on_event("startup")
 async def startup_event():
+    logger.info("Starting background monitor task")
     asyncio.create_task(start_monitor())

--- a/backend/monitor.py
+++ b/backend/monitor.py
@@ -1,7 +1,11 @@
 import asyncio
-import redis.asyncio as aioredis
 import json
+import logging
+
 import httpx
+import redis.asyncio as aioredis
+
+logger = logging.getLogger(__name__)
 
 async def check_node_status(node_id: str, node: dict, redis_client):
     url = f"http://{node['host']}:{node['port']}/wd/hub/status"
@@ -11,11 +15,13 @@ async def check_node_status(node_id: str, node: dict, redis_client):
             if resp.status_code == 200:
                 node_json = await redis_client.hget("nodes", node_id)
                 if not node_json:
+                    logger.debug("Node %s removed before status update", node_id)
                     return
                 data = json.loads(node_json)
                 if data.get("status") != "busy":
                     data["status"] = "online"
                 await redis_client.hset("nodes", node_id, json.dumps(data))
+                logger.debug("Node %s is online", node_id)
             else:
                 raise Exception()
     except Exception:
@@ -25,12 +31,15 @@ async def check_node_status(node_id: str, node: dict, redis_client):
         data = json.loads(node_json)
         data["status"] = "offline"
         await redis_client.hset("nodes", node_id, json.dumps(data))
+        logger.warning("Node %s is offline", node_id)
 
 async def start_monitor():
     redis_client = aioredis.from_url("redis://10.160.13.16:6379/0", decode_responses=True)
+    logger.info("Monitor started")
     while True:
         nodes = await redis_client.hgetall("nodes")
         for node_id, node_data in nodes.items():
             node = json.loads(node_data)
             await check_node_status(node_id, node, redis_client)
+        logger.debug("Completed monitor cycle for %d nodes", len(nodes))
         await asyncio.sleep(10)

--- a/backend/node_manager.py
+++ b/backend/node_manager.py
@@ -1,11 +1,15 @@
-from fastapi import APIRouter, HTTPException
-from typing import Dict
-import uuid
-import redis.asyncio as aioredis
 import json
+import logging
+import uuid
+from typing import Dict
+
+import redis.asyncio as aioredis
+from fastapi import APIRouter, HTTPException
 
 router = APIRouter()
 redis_client = aioredis.from_url("redis://10.160.13.16:6379/0", decode_responses=True)
+
+logger = logging.getLogger(__name__)
 
 @router.post("/register")
 async def register_node(node: Dict):
@@ -21,6 +25,13 @@ async def register_node(node: Dict):
     node.setdefault("status", "online")
 
     await redis_client.hset("nodes", node_id, json.dumps(node))
+    logger.info(
+        "Registered/updated node %s at %s:%s with max_sessions=%s",
+        node_id,
+        node.get("host"),
+        node.get("port"),
+        node.get("max_sessions"),
+    )
     return {"message": "Node registered", "id": node_id}
 
 @router.delete("/unregister/{node_id}")
@@ -28,11 +39,13 @@ async def unregister_node(node_id: str):
     deleted = await redis_client.hdel("nodes", node_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Node not found")
+    logger.info("Unregistered node %s", node_id)
     return {"message": f"Node {node_id} unregistered"}
 
 @router.get("/nodes")
 async def list_nodes():
     nodes = await redis_client.hgetall("nodes")
+    logger.debug("Listing %d nodes", len(nodes))
     return {node_id: json.loads(data) for node_id, data in nodes.items()}
 
 @router.get("/status/{node_id}")
@@ -40,6 +53,7 @@ async def node_status(node_id: str):
     node_data = await redis_client.hget("nodes", node_id)
     if not node_data:
         raise HTTPException(status_code=404, detail="Node not found")
+    logger.debug("Retrieved status for node %s", node_id)
     return json.loads(node_data)
 
 @router.get("/summary")
@@ -47,4 +61,5 @@ async def summary():
     nodes = await redis_client.hgetall("nodes")
     total = len(nodes)
     online = sum(1 for data in nodes.values() if json.loads(data).get("status") == "online")
+    logger.debug("Summary calculated: total=%d, online=%d", total, online)
     return {"total": total, "online": online, "offline": total - online}


### PR DESCRIPTION
## Summary
- add a centralized logging configuration for the backend package
- initialize logging during FastAPI startup and emit lifecycle messages
- instrument routers and monitoring tasks with informative log statements for easier troubleshooting

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68e2e3c43354832ab2713166ad218f4b