### PR TITLE
Add web dashboard for monitoring proxy nodes

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,7 +1,10 @@
 import asyncio
 import logging
+from pathlib import Path
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
 
 from backend.logging_config import setup_logging
 from backend.proxy_router import router as proxy_router
@@ -13,8 +16,21 @@ logger = logging.getLogger(__name__)
 
 app = FastAPI(title="Appium/Selenium Proxy Server")
 
+frontend_dir = Path(__file__).resolve().parent.parent / "frontend"
+
+if frontend_dir.exists():
+    app.mount("/static", StaticFiles(directory=frontend_dir), name="static")
+
 app.include_router(proxy_router)
 app.include_router(node_router)
+
+
+@app.get("/", response_class=FileResponse)
+async def serve_frontend():
+    index_path = frontend_dir / "index.html"
+    if not index_path.exists():
+        raise HTTPException(status_code=404, detail="Frontend not configured")
+    return FileResponse(index_path)
 
 @app.on_event("startup")
 async def startup_event():

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,148 @@
+const tableBody = document.querySelector('#nodes-table tbody');
+const refreshButton = document.querySelector('#refresh-button');
+const toast = document.getElementById('toast');
+const summaryTotal = document.getElementById('summary-total');
+const summaryOnline = document.getElementById('summary-online');
+const summaryOffline = document.getElementById('summary-offline');
+const summaryBusy = document.getElementById('summary-busy');
+const summaryUpdated = document.getElementById('summary-updated');
+
+const STATUS_PRIORITY = ['busy', 'offline', 'online'];
+
+async function fetchJson(endpoint) {
+  const response = await fetch(endpoint);
+  if (!response.ok) {
+    throw new Error(`Request failed: ${response.status}`);
+  }
+  return response.json();
+}
+
+function formatEndpoint(node) {
+  if (!node.host || !node.port) {
+    return '—';
+  }
+  const protocol = node.protocol || 'http';
+  const path = node.path || '/wd/hub';
+  return `${protocol}://${node.host}:${node.port}${path}`;
+}
+
+function deriveStatus(node) {
+  const baseStatus = (node.status || 'offline').toLowerCase();
+  if (baseStatus === 'online') {
+    const maxSessions = Number(node.max_sessions ?? 1);
+    const activeSessions = Number(node.active_sessions ?? 0);
+    if (maxSessions > 0 && activeSessions >= maxSessions) {
+      return 'busy';
+    }
+  }
+  return baseStatus;
+}
+
+function showToast(message) {
+  toast.textContent = message;
+  toast.classList.add('visible');
+  clearTimeout(showToast._timer);
+  showToast._timer = setTimeout(() => {
+    toast.classList.remove('visible');
+  }, 2500);
+}
+
+async function copyNodeDetails(node) {
+  const payload = {
+    id: node.id,
+    endpoint: formatEndpoint(node),
+    status: deriveStatus(node),
+    max_sessions: node.max_sessions,
+    active_sessions: node.active_sessions,
+    platform: node.platform,
+    capabilities: node.capabilities,
+  };
+
+  try {
+    await navigator.clipboard.writeText(JSON.stringify(payload, null, 2));
+    showToast(`Copied details for ${node.id}`);
+  } catch (error) {
+    console.error('Clipboard copy failed', error);
+    showToast('Unable to copy node details');
+  }
+}
+
+function renderRows(nodes) {
+  tableBody.innerHTML = '';
+  if (nodes.length === 0) {
+    tableBody.innerHTML = '<tr><td colspan="5" class="empty-state">No nodes registered yet.</td></tr>';
+    return;
+  }
+
+  const sortedNodes = [...nodes].sort((a, b) => {
+    const statusDiff = STATUS_PRIORITY.indexOf(deriveStatus(a)) - STATUS_PRIORITY.indexOf(deriveStatus(b));
+    if (statusDiff !== 0) {
+      return statusDiff;
+    }
+    return (a.id || '').localeCompare(b.id || '');
+  });
+
+  for (const node of sortedNodes) {
+    const tr = document.createElement('tr');
+
+    const sessionsLabel = `${Number(node.active_sessions ?? 0)} / ${Number(node.max_sessions ?? 1)}`;
+
+    tr.innerHTML = `
+      <td>
+        <div class="node-name">${node.id || 'Unknown node'}</div>
+        <div class="node-meta">${node.platform || ''}</div>
+      </td>
+      <td>
+        <code class="endpoint">${formatEndpoint(node)}</code>
+      </td>
+      <td>${sessionsLabel}</td>
+      <td>
+        <span class="badge" data-status="${deriveStatus(node)}">${deriveStatus(node)}</span>
+      </td>
+      <td>
+        <button class="action-button" data-copy="${node.id}">Copy details</button>
+      </td>
+    `;
+
+    tr.querySelector('button[data-copy]').addEventListener('click', () => copyNodeDetails(node));
+    tableBody.appendChild(tr);
+  }
+}
+
+function updateSummary(nodes) {
+  const total = nodes.length;
+  const counts = nodes.reduce(
+    (acc, node) => {
+      const status = deriveStatus(node);
+      acc[status] = (acc[status] || 0) + 1;
+      return acc;
+    },
+    { online: 0, offline: 0, busy: 0 }
+  );
+
+  summaryTotal.textContent = total;
+  summaryOnline.textContent = counts.online;
+  summaryOffline.textContent = counts.offline;
+  summaryBusy.textContent = counts.busy;
+  summaryUpdated.textContent = new Date().toLocaleTimeString();
+}
+
+async function loadNodes() {
+  tableBody.innerHTML = '<tr><td colspan="5" class="empty-state">Loading nodes...</td></tr>';
+
+  try {
+    const nodeMap = await fetchJson('/nodes');
+    const nodes = Object.values(nodeMap);
+    renderRows(nodes);
+    updateSummary(nodes);
+  } catch (error) {
+    console.error('Failed to load nodes', error);
+    tableBody.innerHTML = '<tr><td colspan="5" class="empty-state">Unable to load nodes. Please try again.</td></tr>';
+    showToast('Failed to load nodes');
+  }
+}
+
+refreshButton.addEventListener('click', loadNodes);
+
+loadNodes();
+setInterval(loadNodes, 15000);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Device Proxy Nodes</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+    <script defer src="/static/app.js"></script>
+  </head>
+  <body>
+    <header class="page-header">
+      <div class="branding">
+        <h1>Device Proxy Nodes</h1>
+        <p class="subtitle">
+          Monitor Appium/Selenium nodes and copy connection details with a single click.
+        </p>
+      </div>
+      <div class="actions">
+        <button id="refresh-button" class="button">Refresh</button>
+      </div>
+    </header>
+
+    <main>
+      <section class="summary" aria-label="Node summary">
+        <div class="summary-card" data-status="total">
+          <span class="summary-label">Total</span>
+          <span id="summary-total" class="summary-value">0</span>
+        </div>
+        <div class="summary-card" data-status="online">
+          <span class="summary-label">Online</span>
+          <span id="summary-online" class="summary-value">0</span>
+        </div>
+        <div class="summary-card" data-status="busy">
+          <span class="summary-label">Busy</span>
+          <span id="summary-busy" class="summary-value">0</span>
+        </div>
+        <div class="summary-card" data-status="offline">
+          <span class="summary-label">Offline</span>
+          <span id="summary-offline" class="summary-value">0</span>
+        </div>
+        <div class="summary-card last-updated">
+          <span class="summary-label">Last updated</span>
+          <span id="summary-updated" class="summary-value">--</span>
+        </div>
+      </section>
+
+      <section class="table-section" aria-label="Node details">
+        <div class="table-header">
+          <h2>Nodes</h2>
+          <p class="table-subtitle">Click the copy button to reuse node details elsewhere.</p>
+        </div>
+        <div class="table-wrapper">
+          <table id="nodes-table">
+            <thead>
+              <tr>
+                <th scope="col">Node</th>
+                <th scope="col">Endpoint</th>
+                <th scope="col">Sessions</th>
+                <th scope="col">Status</th>
+                <th scope="col" class="actions-column">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td colspan="5" class="empty-state">Loading nodes...</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+
+    <div id="toast" role="status" aria-live="polite"></div>
+  </body>
+</html>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,275 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f7f7fb;
+  --surface: #ffffff;
+  --border: #dcdce5;
+  --text: #1f1f33;
+  --text-muted: #5f5f73;
+  --accent: #3f51b5;
+  --online: #2e7d32;
+  --offline: #b71c1c;
+  --busy: #f57c00;
+  --shadow: rgba(31, 31, 51, 0.08);
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 0 1.5rem 2rem;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.page-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 2rem 0 1rem;
+}
+
+.branding h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 2.4vw, 2.5rem);
+}
+
+.subtitle {
+  margin: 0.25rem 0 0;
+  color: var(--text-muted);
+  max-width: 52ch;
+}
+
+.button {
+  appearance: none;
+  border: none;
+  border-radius: 0.75rem;
+  background: var(--accent);
+  color: white;
+  padding: 0.65rem 1.4rem;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  box-shadow: 0 12px 24px -16px rgba(63, 81, 181, 0.8);
+}
+
+.button:hover,
+.button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 28px -16px rgba(63, 81, 181, 0.9);
+}
+
+.button:active {
+  transform: translateY(0);
+  box-shadow: 0 12px 20px -18px rgba(63, 81, 181, 1);
+}
+
+.summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.summary-card {
+  background: var(--surface);
+  border-radius: 1rem;
+  padding: 1.1rem 1.25rem;
+  box-shadow: 0 18px 30px -24px var(--shadow);
+  border: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.summary-card[data-status="online"] .summary-value {
+  color: var(--online);
+}
+
+.summary-card[data-status="offline"] .summary-value {
+  color: var(--offline);
+}
+
+.summary-card[data-status="busy"] .summary-value {
+  color: var(--busy);
+}
+
+.summary-label {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.summary-value {
+  font-size: 1.75rem;
+  font-weight: 700;
+}
+
+.table-section {
+  background: var(--surface);
+  border-radius: 1.2rem;
+  box-shadow: 0 24px 40px -28px var(--shadow);
+  border: 1px solid var(--border);
+  padding: 1.5rem;
+}
+
+.table-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-bottom: 1rem;
+}
+
+.table-header h2 {
+  margin: 0;
+}
+
+.table-subtitle {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+#nodes-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+#nodes-table th,
+#nodes-table td {
+  padding: 0.85rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+}
+
+#nodes-table code.endpoint {
+  background: rgba(31, 31, 51, 0.06);
+  padding: 0.35rem 0.55rem;
+  border-radius: 0.5rem;
+  font-size: 0.9rem;
+  display: inline-block;
+  word-break: break-all;
+}
+
+#nodes-table .node-name {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+#nodes-table .node-meta {
+  margin-top: 0.2rem;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+#nodes-table th {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+}
+
+#nodes-table tbody tr:hover {
+  background: rgba(63, 81, 181, 0.04);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  background: rgba(31, 31, 51, 0.08);
+  color: var(--text);
+  text-transform: capitalize;
+}
+
+.badge[data-status="online"] {
+  background: rgba(46, 125, 50, 0.12);
+  color: var(--online);
+}
+
+.badge[data-status="offline"] {
+  background: rgba(183, 28, 28, 0.12);
+  color: var(--offline);
+}
+
+.badge[data-status="busy"] {
+  background: rgba(245, 124, 0, 0.12);
+  color: var(--busy);
+}
+
+.actions-column {
+  width: 140px;
+}
+
+.action-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
+}
+
+.action-button:hover,
+.action-button:focus-visible {
+  background: rgba(63, 81, 181, 0.08);
+  border-color: rgba(63, 81, 181, 0.35);
+  transform: translateY(-1px);
+}
+
+.empty-state {
+  text-align: center;
+  color: var(--text-muted);
+  padding: 2.5rem 0;
+}
+
+#toast {
+  position: fixed;
+  inset: auto 1.5rem 1.5rem auto;
+  background: var(--accent);
+  color: white;
+  padding: 0.75rem 1.2rem;
+  border-radius: 0.75rem;
+  box-shadow: 0 18px 40px -20px rgba(63, 81, 181, 0.9);
+  opacity: 0;
+  transform: translateY(12px);
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  font-weight: 600;
+}
+
+#toast.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (max-width: 640px) {
+  body {
+    padding: 0 1rem 1.5rem;
+  }
+
+  .page-header {
+    padding-top: 1.5rem;
+  }
+
+  .actions-column {
+    width: auto;
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 fastapi
+aiofiles
 uvicorn
 httpx
 redis


### PR DESCRIPTION
## Summary
- mount a static frontend and root handler in FastAPI to serve a node monitoring dashboard
- introduce a responsive dashboard that surfaces node counts, status badges, and copy-to-clipboard actions
- declare aiofiles dependency required for FastAPI static file serving

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68e4264a5c80832a83a83eea063a6259