### PR TITLE
Add Dockerized frontend service and compose integration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,3 +5,12 @@ services:
     image: appium-selenium-proxy
     ports:
       - "8080:8090"
+
+  frontend:
+    build:
+      context: ./frontend
+    image: device-proxy-frontend
+    depends_on:
+      - proxy
+    ports:
+      - "3000:80"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,11 @@
+FROM nginx:1.25-alpine
+
+RUN rm -rf /usr/share/nginx/html/* \
+    && mkdir -p /usr/share/nginx/html/static
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY index.html /usr/share/nginx/html/index.html
+COPY app.js /usr/share/nginx/html/static/app.js
+COPY styles.css /usr/share/nginx/html/static/styles.css
+
+EXPOSE 80

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,27 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    access_log /var/log/nginx/access.log;
+    error_log /var/log/nginx/error.log;
+
+    location /static/ {
+        try_files $uri =404;
+    }
+
+    location ~ ^/(nodes|register|unregister|status|summary|wd/hub|session)(/.*)?$ {
+        proxy_pass http://proxy:8090$request_uri;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary
- add an Nginx-based Docker image to serve the frontend assets
- configure the Nginx proxy to forward API traffic to the backend container
- extend docker-compose to build and run the new frontend alongside the proxy service

## Testing
- _No automated tests were run (docker tooling unavailable in the environment)_

------
https://chatgpt.com/codex/tasks/task_e_68e42998a378832aaf10522eac023283