### PR TITLE
Allow cross-origin requests

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3,6 +3,7 @@ import logging
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
@@ -15,6 +16,14 @@ setup_logging()
 logger = logging.getLogger(__name__)
 
 app = FastAPI(title="Appium/Selenium Proxy Server")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=False,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 frontend_dir = Path(__file__).resolve().parent.parent / "frontend"
 


### PR DESCRIPTION
## Summary
- enable CORS middleware on the FastAPI application so the frontend can reach the backend API

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e42bfb46f0832aab491c70f2983271