### PR TITLE
Load node resources from CSV and enforce UDID uniqueness

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -9,7 +9,7 @@ from fastapi.staticfiles import StaticFiles
 
 from backend.logging_config import setup_logging
 from backend.proxy_router import router as proxy_router
-from backend.node_manager import router as node_router
+from backend.node_manager import load_nodes_from_csv, router as node_router
 from backend.monitor import start_monitor
 
 setup_logging()
@@ -43,5 +43,6 @@ async def serve_frontend():
 
 @app.on_event("startup")
 async def startup_event():
+    await load_nodes_from_csv()
     logger.info("Starting background monitor task")
     asyncio.create_task(start_monitor())

--- a/backend/node_resources.csv
+++ b/backend/node_resources.csv
@@ -1,0 +1,1 @@
+id,type,udid,host,port,protocol,path,max_sessions,active_sessions,status,platform,platform_version,device_name,resources

--- a/backend/node_resources_template.csv
+++ b/backend/node_resources_template.csv
@@ -1,0 +1,2 @@
+id,type,udid,host,port,protocol,path,max_sessions,active_sessions,status,platform,platform_version,device_name,resources
+example-node-id,physical,00008020-001C2D113C88002E,127.0.0.1,4723,http,/wd/hub,1,0,online,iOS,17.4,Example Device,"{""session_data"": {""device"": ""metadata""}}"


### PR DESCRIPTION
## Summary
- load node definitions from a CSV file on startup and expose an endpoint to refresh the data
- enforce physical device uniqueness by UDID while keeping emulator registrations unchanged
- add default CSV/template files to simplify preparing node resource uploads

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68e4338babdc832aa7201a0ecd43f04e