### PR TITLE
Update node details modal to include endpoint info

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -64,7 +64,6 @@
             <thead>
               <tr>
                 <th scope="col">Node</th>
-                <th scope="col">Endpoint</th>
                 <th scope="col">Sessions</th>
                 <th scope="col">Status</th>
                 <th scope="col" class="actions-column">Actions</th>
@@ -72,7 +71,7 @@
             </thead>
             <tbody>
               <tr>
-                <td colspan="5" class="empty-state">Loading nodes...</td>
+                <td colspan="4" class="empty-state">Loading nodes...</td>
               </tr>
             </tbody>
           </table>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -296,6 +296,17 @@ body {
   transform: translateY(0);
 }
 
+.action-button[disabled],
+.action-button[disabled]:hover,
+.action-button[disabled]:focus-visible {
+  background: var(--border);
+  border-color: var(--border);
+  color: var(--text-muted);
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
 .empty-state {
   text-align: center;
   color: var(--text-muted);


### PR DESCRIPTION
## Summary
- remove the endpoint column from the nodes table and adjust empty states
- show the node endpoint alongside metadata inside the details modal
- disable the details button for offline or busy nodes and add disabled styling

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e482af7d00832ab22450b4653be05f