### PR TITLE
Serve frontend over HTTP on 8080

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Once the configuration is in place, reload the UI. Eligible devices will display
 
 ## SSL/HTTPS Configuration
 
-The Device Proxy can be configured to run with SSL/HTTPS encryption on port 443.
+By default the frontend now serves plain HTTP on port **8080**. If you need HTTPS, you can opt in by following one of the SSL setup guides below.
 
 ### Quick Setup (Docker-Only - Recommended)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,4 @@ services:
     depends_on:
       - proxy
     ports:
-      - "443:443"
-    volumes:
-      - ./ssl/tls.crt:/etc/nginx/ssl/cert.crt:ro
-      - ./ssl/tls.key:/etc/nginx/ssl/cert.key:ro
+      - "8080:8080"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,4 +11,4 @@ COPY embed.js /usr/share/nginx/html/static/embed.js
 COPY styles.css /usr/share/nginx/html/static/styles.css
 COPY embed.css /usr/share/nginx/html/static/embed.css
 
-EXPOSE 443
+EXPOSE 8080

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,16 +1,7 @@
-# HTTPS server - SSL handled inside Docker container
+# HTTP server (no SSL)
 server {
-    listen 443 ssl;
+    listen 8080;
     server_name _;
-
-    # SSL certificate configuration
-    ssl_certificate /etc/nginx/ssl/cert.crt;
-    ssl_certificate_key /etc/nginx/ssl/cert.key;
-
-    # SSL configuration for better security
-    ssl_protocols TLSv1.2 TLSv1.3;
-    ssl_ciphers HIGH:!aNULL:!MD5;
-    ssl_prefer_server_ciphers on;
 
     root /usr/share/nginx/html;
     index index.html;


### PR DESCRIPTION
## Summary
- update the frontend nginx config to serve over plain HTTP on port 8080
- adjust Docker Compose and Dockerfile to publish port 8080 without SSL assets
- note the default HTTP port change in the README

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933b4bcf720832a8aab24f8e277273f)