### PR TITLE
Add iframe to access external STF service

### DIFF
--- a/backend/node_manager.py
+++ b/backend/node_manager.py
@@ -336,7 +336,7 @@ def _build_stf_control_url(node: Dict, stf_config: Dict) -> str:
 
     base_url = base_url.rstrip("/")
     if template.startswith("#"):
-        return f"{base_url}/{template}"
+        return f"{base_url}{template}"
     if template.startswith("/"):
         return f"{base_url}{template}"
     if not template:


### PR DESCRIPTION
The _build_stf_control_url function was incorrectly adding a "/" separator before hash fragments. Hash fragments should be appended directly to URLs without any separator, regardless of whether the URL contains query parameters.

This fix ensures that when clicking the "Use" button, the iframe navigates to the full URL including the hash fragment (e.g., #!/control/RFCN80T4GDJ).

Fixed:
- Changed line 339 to append hash fragments directly: f"{base_url}{template}"
- Previously: f"{base_url}/{template}" (incorrect - added extra "/" before hash)